### PR TITLE
組織・カテゴリ情報の取得時にキャッシュするようにする

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'com.dxjunkyard'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2-beta'
 
 java {
     sourceCompatibility = '17'
@@ -31,8 +31,6 @@ dependencies {
         'org.springframework.boot:spring-boot-starter-webflux',
         'org.springdoc:springdoc-openapi-starter-webflux-ui:2.2.0',
         'org.springframework.boot:spring-boot-starter-actuator',
-        'org.springframework.boot:spring-boot-starter-cache',
-        'com.github.ben-manes.caffeine:caffeine',
         'org.apache.commons:commons-collections4:4.4',
     )
     compileOnly(
@@ -64,16 +62,6 @@ test {
         showStandardStreams true
         // イベントを出力する (TestLogEvent)
         events 'started', 'skipped', 'passed', 'failed'
-    }
-}
-
-
-openApi {
-    apiDocsUrl.set("http://localhost:8080/openapi.json")
-    outputDir.set(file("$buildDir/docs"))
-    outputFileName.set("openapi.json")
-    customBootRun {
-        args.set(["--spring.profiles.active=prod-doc"])
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = 'com.dxjunkyard'
-version = '0.0.2-beta'
+version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '17'

--- a/src/main/java/com/dxjunkyard/opendata/platform/config/CacheConfig.java
+++ b/src/main/java/com/dxjunkyard/opendata/platform/config/CacheConfig.java
@@ -1,31 +1,29 @@
 package com.dxjunkyard.opendata.platform.config;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
+import com.dxjunkyard.opendata.platform.domain.model.search.CategoryNameToIdConverter;
+import com.dxjunkyard.opendata.platform.domain.model.search.OrganizationNameToIdConverter;
+import com.dxjunkyard.opendata.platform.domain.repository.opendata.OpenDataRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.NonNull;
 
-import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 
 @Configuration
-@EnableCaching
 public class CacheConfig {
     @Bean
-    public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
-        cacheManager.setCaffeine(caffeineCacheBuilder());
-        return cacheManager;
+    @NonNull
+    public CategoryNameToIdConverter categoryNameToIdConverter(final OpenDataRepository openDataRepository) {
+        final var category =  openDataRepository.fetchCategory().block();
+        return Optional.ofNullable(category)
+            .orElseGet(CategoryNameToIdConverter::init);
     }
 
+    @Bean
     @NonNull
-    private Caffeine<Object, Object> caffeineCacheBuilder() {
-        return Caffeine.newBuilder()
-            .initialCapacity(100)
-            .maximumSize(500)
-            .expireAfterAccess(10, TimeUnit.MINUTES)
-            .recordStats();
+    public OrganizationNameToIdConverter organizationNameToIdConverter(final OpenDataRepository openDataRepository) {
+        final var organization = openDataRepository.fetchOrganization().block();
+        return Optional.ofNullable(organization)
+            .orElseGet(OrganizationNameToIdConverter::init);
     }
 }

--- a/src/main/java/com/dxjunkyard/opendata/platform/domain/model/search/CategoryNameToIdConverter.java
+++ b/src/main/java/com/dxjunkyard/opendata/platform/domain/model/search/CategoryNameToIdConverter.java
@@ -35,7 +35,7 @@ public class CategoryNameToIdConverter {
     }
 
     @NonNull
-    public Set<String> getCategoryNameList() {
+    public Set<String> getCategoryNameSet() {
         return map.keySet();
     }
 }

--- a/src/main/java/com/dxjunkyard/opendata/platform/domain/model/search/OrganizationNameToIdConverter.java
+++ b/src/main/java/com/dxjunkyard/opendata/platform/domain/model/search/OrganizationNameToIdConverter.java
@@ -34,7 +34,7 @@ public class OrganizationNameToIdConverter {
     }
 
     @NonNull
-    public Set<String> getOrganizationNameList() {
+    public Set<String> getOrganizationNameSet() {
         return map.keySet();
     }
 }

--- a/src/main/java/com/dxjunkyard/opendata/platform/presentation/controller/OpenDataSearcherController.java
+++ b/src/main/java/com/dxjunkyard/opendata/platform/presentation/controller/OpenDataSearcherController.java
@@ -1,6 +1,8 @@
 package com.dxjunkyard.opendata.platform.presentation.controller;
 
 import com.dxjunkyard.opendata.platform.application.service.SearchOpenDataService;
+import com.dxjunkyard.opendata.platform.domain.model.opendata.OpenData;
+import com.dxjunkyard.opendata.platform.domain.model.search.condition.SearchCondition;
 import com.dxjunkyard.opendata.platform.presentation.dto.factory.OpenDataSearcherFactory;
 import com.dxjunkyard.opendata.platform.presentation.dto.request.OpenDataSearcherRequest;
 import com.dxjunkyard.opendata.platform.presentation.dto.response.OpenDataSearcherResponse;
@@ -40,9 +42,11 @@ public class OpenDataSearcherController {
     })
     @GetMapping("/search")
     public Mono<OpenDataSearcherResponse> searchOpenData(@ParameterObject @Validated final OpenDataSearcherRequest request) {
-        return openDataSearcherFactory.build(request)
-            .flatMap(searchCondition -> searchOpenDataService
-                .search(searchCondition)
-                .map(openData -> openDataSearcherFactory.build(openData, searchCondition)));
+
+        final SearchCondition searchCondition = openDataSearcherFactory.build(request);
+
+        final Mono<OpenData> openDataMono = searchOpenDataService.search(searchCondition);
+
+        return openDataMono.map(openData -> openDataSearcherFactory.build(openData, searchCondition));
     }
 }

--- a/src/main/java/com/dxjunkyard/opendata/platform/presentation/dto/response/OpenDataSearcherResponse.java
+++ b/src/main/java/com/dxjunkyard/opendata/platform/presentation/dto/response/OpenDataSearcherResponse.java
@@ -1,5 +1,6 @@
 package com.dxjunkyard.opendata.platform.presentation.dto.response;
 
+import com.dxjunkyard.opendata.platform.domain.model.search.condition.SearchCondition;
 import lombok.Builder;
 import org.springframework.lang.NonNull;
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 組織・カテゴリ情報をbeanに保存する
- 保存した組織・カテゴリ情報を呼び出して利用する

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
API実行時に組織・カテゴリ情報を外部から取得しなくなった
```
2023-08-16T23:16:41.512+09:00  INFO 42969 --- [ctor-http-nio-4] c.d.o.p.config.RequestLoggingFilter      : Request: GET http://localhost:8080/opendata/v1/search?page=1&organization=%E7%A8%8E%E9%87%91 Host: localhost:8080, Connection: keep-alive, sec-ch-ua: "Not/A)Brand";v="99", "Google Chrome";v="115", "Chromium";v="115", accept: application/json, sec-ch-ua-mobile: ?0, User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36, sec-ch-ua-platform: "macOS", Sec-Fetch-Site: same-origin, Sec-Fetch-Mode: cors, Sec-Fetch-Dest: empty, Referer: http://localhost:8080/webjars/swagger-ui/index.html, Accept-Encoding: gzip, deflate, br, Accept-Language: ja-JP,ja;q=0.9,en-US;q=0.8,en;q=0.7
2023-08-16T23:16:41.597+09:00  INFO 42969 --- [ctor-http-nio-4] c.d.o.p.i.r.config.WebClientConfig       : Request: GET https://catalog.data.metro.tokyo.lg.jp/api/3/action/package_search?q=%E7%A8%8E%E9%87%91&start=0&rows=5
2023-08-16T23:16:41.659+09:00  INFO 42969 --- [ctor-http-nio-2] c.d.o.p.i.r.config.WebClientConfig       : Response: 200 OK
```
